### PR TITLE
Added 202 as a possible status code for the prototype set method.

### DIFF
--- a/context.go
+++ b/context.go
@@ -261,7 +261,7 @@ func (c *Context) prototypeStateSetKey(id uint, key string, value string) error 
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != 200 && resp.StatusCode != 202 {
 		return fmt.Errorf("Error while inserting entry: Unexpected status code: %d", resp.StatusCode)
 	}
 	return nil


### PR DESCRIPTION
In case the `waitForApplied` options is set to true, the prototype responds with `OK`. Otherwise, it responds with `ACCEPTED`.